### PR TITLE
Removed trailing comma parsing error

### DIFF
--- a/apiDocAutocompletion.sublime-settings
+++ b/apiDocAutocompletion.sublime-settings
@@ -1,4 +1,4 @@
 {
     // Disables the plugin
-    "disabled": false,
+    "disabled": false
 }


### PR DESCRIPTION
Trailing comma before closing bracket gives an alert in ST.
